### PR TITLE
Update Ork.Formatting to be case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+* Convert method and property names to lowercase in Ork.Formatting before
+  checking for alphabetical order.
+
 ## 2.0.12
 
 * Removed Squiz.WhiteSpace.ObjectOperatorSpacing.Before sniff to allow

--- a/Ork/Sniffs/Formatting/AlphabeticalMethodNamesSniff.php
+++ b/Ork/Sniffs/Formatting/AlphabeticalMethodNamesSniff.php
@@ -63,11 +63,11 @@ class AlphabeticalMethodNamesSniff implements Sniff
         // We only care about class methods, so ignore global functions (level 0).
         if ($tokens[$stackPtr]['level'] === 1) {
             $methodName = $phpcsFile->getDeclarationName($stackPtr);
-            if ($this->lastMethodName !== null && $methodName <= $this->lastMethodName) {
+            if ($this->lastMethodName !== null && strtolower($methodName) <= $this->lastMethodName) {
                 $phpcsFile->addError('Method "%s" is not in alphabetical order.', $stackPtr, 'OutOfOrder', [$methodName]);
             }
 
-            $this->lastMethodName = $methodName;
+            $this->lastMethodName = strtolower($methodName);
         }
 
     }//end process()

--- a/Ork/Sniffs/Formatting/AlphabeticalPropertyNamesSniff.php
+++ b/Ork/Sniffs/Formatting/AlphabeticalPropertyNamesSniff.php
@@ -65,13 +65,13 @@ class AlphabeticalPropertyNamesSniff implements Sniff
         if ($tokens[$stackPtr]['level'] === 1) {
             $propertyName = substr($tokens[$stackPtr]['content'], 1);
             if ($this->lastPropertyName !== null
-                && $propertyName <= $this->lastPropertyName
+                && strtolower($propertyName) <= $this->lastPropertyName
                 && array_key_exists('nested_parenthesis', $tokens[$stackPtr]) === false
             ) {
                 $phpcsFile->addError('Property "%s" is not in alphabetical order.', $stackPtr, 'OutOfOrder', [$propertyName]);
             }
 
-            $this->lastPropertyName = $propertyName;
+            $this->lastPropertyName = strtolower($propertyName);
         }
 
     }//end process()

--- a/Ork/Tests/Formatting/IgnoreCase.php
+++ b/Ork/Tests/Formatting/IgnoreCase.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Sample class demonstrating sorting issues between ASCII and English.
+ *
+ * @package   Ork.Tests.Formatting
+ * @copyright sommeone
+ */
+
+namespace Ork\Tests\Formatting;
+
+/**
+ * Sample class demonstrating sorting issues between ASCII and English.
+ */
+class IgnoreCase
+{
+
+    /**
+     * Member var doc comment
+     *
+     * @var object[]
+     */
+    protected $boxes;
+
+    /**
+     * Member var doc comment
+     *
+     * @var object[]
+     */
+    protected $boxModels;
+
+    /**
+     * Function comment
+     *
+     * @return void
+     */
+    protected function getBoxes()
+    {
+    }
+
+    /**
+     * Function comment
+     *
+     * @return void
+     */
+    protected function getBoxModels()
+    {
+    }
+
+}


### PR DESCRIPTION
Added a sample class demonstrating the issue I encountered with sorting method and property names.

Added a proposed fix for the issue.